### PR TITLE
Interface Restructuring and Renaming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["tests", "work"]
 
 [project]
 name = "ragl"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
     "bleach",
     "numpy",

--- a/ragl/__init__.py
+++ b/ragl/__init__.py
@@ -7,7 +7,7 @@ Generation (RAG) systems.
 
 import logging
 
-from ragl.registry import create_rag_manager
+from ragl.factory import create_rag_manager
 from ragl.textunit import TextUnit
 
 

--- a/ragl/factory.py
+++ b/ragl/factory.py
@@ -68,7 +68,7 @@ class AbstractFactory:
             List of factory class names that can call the abstract
             __call__ method. This is used to prevent subclasses from
             calling the abstract __call__ method directly.
-        _config_cls:
+        config_cls:
             Configuration class type associated with this factory
         _factory_map:
             Dictionary mapping config class types to factory instances
@@ -81,7 +81,7 @@ class AbstractFactory:
 
     The factory uses configuration class names as keys to determine
     which concrete implementation to instantiate. Subclasses should set
-    _config_cls or pass config_cls in __init_subclass__ to enable
+    config_cls or pass config_cls in __init_subclass__ to enable
     automatic registration.
 
     Raises:
@@ -94,7 +94,7 @@ class AbstractFactory:
     can_call_abstract__call__: ClassVar[list] = ['EmbedderFactory',
                                                  'VectorStoreFactory']
 
-    _config_cls: ClassVar[type[RaglConfig] | None] = None
+    config_cls: ClassVar[type[RaglConfig] | None] = None
     _factory_map: ClassVar[dict[type[RaglConfig], type[Self]]] = {}
 
     def __init_subclass__(cls, **kwargs):
@@ -110,7 +110,7 @@ class AbstractFactory:
                 keyword arguments are ignored and passed to the parent
                 class's __init_subclass__ method.
         """
-        config_cls = kwargs.pop('config_cls', cls._config_cls)
+        config_cls = kwargs.pop('config_cls', cls.config_cls)
         super().__init_subclass__(**kwargs)
 
         if cls._is_direct_subclass():
@@ -255,8 +255,8 @@ class AbstractFactory:
             A string showing the factory class name, config class, and
             factory map.
         """
-        if self._config_cls:
-            config_cls_name = self._config_cls.__name__
+        if self.config_cls:
+            config_cls_name = self.config_cls.__name__
         else:
             config_cls_name = None
 
@@ -285,7 +285,7 @@ class EmbedderFactory(AbstractFactory):
 class SentenceTransformerFactory(EmbedderFactory):
     """Factory for creating SentenceTransformer embedder instances."""
 
-    _config_cls = SentenceTransformerConfig
+    config_cls = SentenceTransformerConfig
 
     def __call__(self, *args, **kwargs) -> Any:
         """
@@ -337,7 +337,7 @@ class VectorStoreFactory(AbstractFactory):
 class RedisVectorStoreFactory(VectorStoreFactory):
     """Factory for creating RedisVectorStore instances."""
 
-    _config_cls = RedisConfig
+    config_cls = RedisConfig
 
     def __call__(self, *args, **kwargs) -> Any:
         """

--- a/ragl/manager.py
+++ b/ragl/manager.py
@@ -350,10 +350,10 @@ class RAGManager:
                     msg = 'Text cannot be empty'
                     _LOG.critical(msg)
                     raise ValidationError(msg)
-                text_or_doc = self._sanitize_query(text_or_doc)
+                text_or_doc = self._sanitize_text(text_or_doc)
 
             elif isinstance(text_or_doc, TextUnit):
-                text_or_doc.text = self._sanitize_query(text_or_doc.text)
+                text_or_doc.text = self._sanitize_text(text_or_doc.text)
 
             if base_id:
                 parent_id = base_id
@@ -451,7 +451,7 @@ class RAGManager:
             return []
 
         with self.track_operation('get_context'):
-            self._sanitize_query(query)
+            self._sanitize_text(query)
             self._validate_query(query)
             self._validate_top_k(top_k)
 
@@ -667,7 +667,7 @@ class RAGManager:
             return [text_or_doc.text]
         return [text_or_doc]
 
-    def _sanitize_query(self, text: str) -> str:
+    def _sanitize_text(self, text: str) -> str:
         """
         Validate and sanitize text input to prevent injection attacks.
 

--- a/ragl/protocols.py
+++ b/ragl/protocols.py
@@ -44,11 +44,11 @@ class EmbedderProtocol(Protocol):
     """
 
     @property
-    def dimensions(self) -> int:  # noqa: D102
+    def dimensions(self) -> int:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
-    def embed(self, text: str) -> np.ndarray:  # noqa: D102
+    def embed(self, text: str) -> np.ndarray:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
@@ -61,11 +61,11 @@ class VectorStoreProtocol(Protocol):
     Defines methods for storing and retrieving vectors.
     """
 
-    def clear(self) -> None:  # noqa: D102
+    def clear(self) -> None:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
-    def delete_text(self, text_id: str) -> bool:  # noqa: D102
+    def delete_text(self, text_id: str) -> bool:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
@@ -80,11 +80,11 @@ class VectorStoreProtocol(Protocol):
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
-    def health_check(self) -> dict[str, Any]:  # noqa: D102
+    def health_check(self) -> dict[str, Any]:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
-    def list_texts(self) -> list[str]:  # noqa: D102
+    def list_texts(self) -> list[str]:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
@@ -104,11 +104,11 @@ class RAGStoreProtocol(Protocol):
     embedder: EmbedderProtocol
     storage: VectorStoreProtocol
 
-    def clear(self) -> None:  # noqa: D102
+    def clear(self) -> None:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
-    def delete_text(self, text_id: str) -> bool:  # noqa: D102
+    def delete_text(self, text_id: str) -> bool:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
@@ -119,15 +119,15 @@ class RAGStoreProtocol(Protocol):
             *,
             min_time: int | None,
             max_time: int | None,
-    ) -> list[TextUnit]:  # noqa: D102
+    ) -> list[TextUnit]:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
-    def list_texts(self) -> list[str]:  # noqa: D102
+    def list_texts(self) -> list[str]:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
-    def store_text(self, text_unit: TextUnit) -> TextUnit:  # noqa: D102
+    def store_text(self, text_unit: TextUnit) -> TextUnit:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
@@ -140,10 +140,10 @@ class TokenizerProtocol(Protocol):
     Defines methods for encoding and decoding text.
     """
 
-    def decode(self, tokens: list[int]) -> str:  # noqa: D102
+    def decode(self, tokens: list[int]) -> str:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover
 
-    def encode(self, text: str) -> list[int]:  # noqa: D102
+    def encode(self, text: str) -> list[int]:
         # pylint: disable=missing-function-docstring
         ...  # pragma: no cover

--- a/ragl/store/redis.py
+++ b/ragl/store/redis.py
@@ -501,7 +501,7 @@ class RedisVectorStore:
 
         if text_id is None:
             _LOG.info('generating text_id')
-            text_id = self._generate_text_id(text_id)
+            text_id = self._generate_text_id()
 
         self._validate_input_sizes(text, text_data)
         self._validate_text_id(text_id)
@@ -664,7 +664,7 @@ class RedisVectorStore:
                                                   'unknown'),
         }
 
-    def _generate_text_id(self, text_id: str | None) -> str:
+    def _generate_text_id(self) -> str:
         """
         Generate a unique text ID.
 
@@ -672,17 +672,12 @@ class RedisVectorStore:
         counter to ensure uniqueness. If a text ID is provided,
         it's returned unchanged.
 
-        Args:
-            text_id:
-                Optional provided ID.
-
         Returns:
-            Generated or provided text ID.
+            Generated text ID.
         """
-        if text_id is None:
-            with self.redis_context() as client:
-                counter = client.incr(self.TEXT_COUNTER_KEY)
-            text_id = f'{TEXT_ID_PREFIX}{counter}'
+        with self.redis_context() as client:
+            counter = client.incr(self.TEXT_COUNTER_KEY)
+        text_id = f'{TEXT_ID_PREFIX}{counter}'
         return text_id
 
     def _parse_tags_from_retrieval(

--- a/tests/functional/ragl/store/test_redis.py
+++ b/tests/functional/ragl/store/test_redis.py
@@ -645,27 +645,11 @@ class TestRedisVectorStore(unittest.TestCase):
 
         self.mock_redis_client.incr.return_value = 123
 
-        result = store._generate_text_id(None)
+        result = store._generate_text_id()
 
         self.assertEqual(result, f'{TEXT_ID_PREFIX}123')
         self.mock_redis_client.incr.assert_called_once_with(
             RedisVectorStore.TEXT_COUNTER_KEY)
-
-    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
-    def test_generate_text_id_provided(self, mock_validate_sync):
-        """Test generating text ID when provided."""
-        with patch.object(RedisVectorStore, '_enforce_schema_version'):
-            store = RedisVectorStore(
-                redis_client=self.mock_redis_client,
-                dimensions=self.dimensions,
-                index_name=self.index_name
-            )
-
-        provided_id = f'{TEXT_ID_PREFIX}custom'
-        result = store._generate_text_id(provided_id)
-
-        self.assertEqual(result, provided_id)
-        self.mock_redis_client.incr.assert_not_called()
 
     @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
     def test_parse_tags_from_retrieval_none(self, mock_validate_sync):

--- a/tests/functional/ragl/test_factory.py
+++ b/tests/functional/ragl/test_factory.py
@@ -11,7 +11,7 @@ import unittest
 from unittest.mock import Mock, patch
 from typing import Any
 
-from ragl.registry import (
+from ragl.factory import (
     AbstractFactory,
     EmbedderFactory,
     VectorStoreFactory,
@@ -37,7 +37,7 @@ class MockConfig(RaglConfig):
 
 class MockFactory(AbstractFactory):
     """Mock factory class for testing."""
-    _config_cls = MockConfig
+    config_cls = MockConfig
 
     def __call__(self, *args, **kwargs) -> Any:
         return Mock()
@@ -62,7 +62,7 @@ class TestAbstractFactory(unittest.TestCase):
         """Test that direct subclasses get their own factory map."""
 
         class TestDirectFactory(AbstractFactory):
-            _config_cls = MockConfig
+            config_cls = MockConfig
 
         self.assertIsInstance(TestDirectFactory._factory_map, dict)
         self.assertIn(MockConfig, TestDirectFactory._factory_map)
@@ -253,7 +253,7 @@ class TestSentenceTransformerFactory(unittest.TestCase):
 
     def test_sentence_transformer_factory_config_cls(self):
         """Test that SentenceTransformerFactory has correct config class."""
-        self.assertEqual(SentenceTransformerFactory._config_cls,
+        self.assertEqual(SentenceTransformerFactory.config_cls,
                          SentenceTransformerConfig)
 
     def test_call_missing_config(self):
@@ -308,7 +308,7 @@ class TestRedisVectorStoreFactory(unittest.TestCase):
 
     def test_redis_vector_store_factory_config_cls(self):
         """Test that RedisVectorStoreFactory has correct config class."""
-        self.assertEqual(RedisVectorStoreFactory._config_cls, RedisConfig)
+        self.assertEqual(RedisVectorStoreFactory.config_cls, RedisConfig)
 
     def test_call_missing_config(self):
         """Test __call__ without config parameter."""
@@ -380,10 +380,10 @@ class TestRedisVectorStoreFactory(unittest.TestCase):
 class TestCreateRagManager(unittest.TestCase):
     """Test cases for create_rag_manager function."""
 
-    @patch('ragl.registry.RAGManager')
-    @patch('ragl.registry.RAGStore')
-    @patch('ragl.registry.VectorStoreFactory')
-    @patch('ragl.registry.EmbedderFactory')
+    @patch('ragl.factory.RAGManager')
+    @patch('ragl.factory.RAGStore')
+    @patch('ragl.factory.VectorStoreFactory')
+    @patch('ragl.factory.EmbedderFactory')
     def test_create_rag_manager_success(self, mock_embedder_factory_class,
                                         mock_vector_store_factory_class,
                                         mock_rag_store_class,
@@ -454,7 +454,7 @@ class TestLogging(unittest.TestCase):
         factory = EmbedderFactory()
         config = MockConfig()
 
-        with self.assertLogs('ragl.registry', level='DEBUG') as log:
+        with self.assertLogs('ragl.factory', level='DEBUG') as log:
             factory(config=config)
 
         # Verify debug messages are logged
@@ -466,7 +466,7 @@ class TestLogging(unittest.TestCase):
         """Test critical logging when errors occur."""
         factory = EmbedderFactory()
 
-        with self.assertLogs('ragl.registry', level='CRITICAL') as log:
+        with self.assertLogs('ragl.factory', level='CRITICAL') as log:
             try:
                 factory()  # Missing config
             except ConfigurationError:

--- a/tests/functional/ragl/test_manager.py
+++ b/tests/functional/ragl/test_manager.py
@@ -821,7 +821,7 @@ class TestRAGManager(unittest.TestCase):
                              tokenizer=self.mock_tokenizer)
         text = "Normal text input"
 
-        result = manager._sanitize_query(text)
+        result = manager._sanitize_text(text)
 
         self.assertEqual(result, text)
         mock_log.debug.assert_called_with('Sanitizing text')
@@ -835,7 +835,7 @@ class TestRAGManager(unittest.TestCase):
 
         with patch('ragl.manager._LOG') as mock_log:
             with self.assertRaises(ValidationError) as cm:
-                manager._sanitize_query(long_text)
+                manager._sanitize_text(long_text)
 
             self.assertIn('text too long', str(cm.exception))
             mock_log.critical.assert_called_with('text too long')
@@ -847,7 +847,7 @@ class TestRAGManager(unittest.TestCase):
                              tokenizer=self.mock_tokenizer)
         text = "Text with <script>alert('xss')</script> dangerous chars!"
 
-        result = manager._sanitize_query(text)
+        result = manager._sanitize_text(text)
 
         # Should remove dangerous characters, keeping only alphanumeric, spaces, and basic punctuation
         expected = "Text with alert('xss') dangerous chars!"

--- a/tests/integration/sentencetransformer_redis.py
+++ b/tests/integration/sentencetransformer_redis.py
@@ -11,7 +11,7 @@ from ragl.config import (
     SentenceTransformerConfig,
 )
 from ragl.exceptions import ValidationError
-from ragl.registry import create_rag_manager
+from ragl.factory import create_rag_manager
 from ragl.textunit import TextUnit
 
 
@@ -48,7 +48,7 @@ class TestRAGLIntegration:
     def test_text_sanitization(self):
         """Test text input sanitization."""
         malicious_text = "Text with <script>alert('xss')</script> chars!"
-        result = self.manager._sanitize_query(malicious_text)
+        result = self.manager._sanitize_text(malicious_text)
         assert "<script>" not in result
         logging.info(f"Sanitized text: {result}")
 


### PR DESCRIPTION
Interface Restructuring and Renaming
- Rename: registry.py -> factory.py
- Rename sanitize_query -> sanitize_text
- Rename: EmbedderFactory._config_cls -> EmbedderFactory.config_cls
- Get rid of unecessary noqa directives in protocols.py
- RedisVectorStore.generate_text_id() no longer accepts a param