### PR TITLE
TextUnit Refactor (non-breaking)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["tests", "work"]
 
 [project]
 name = "ragl"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
     "bleach",
     "numpy",

--- a/ragl/store/redis.py
+++ b/ragl/store/redis.py
@@ -563,6 +563,7 @@ class RedisVectorStore:
             text_id = text_unit.text_id
             if text_id is None:
                 text_id = self._generate_text_id()
+                text_unit.text_id = text_id
 
             self._validate_input_sizes(text, text_data)
             self._validate_text_id(text_id)

--- a/ragl/textunit.py
+++ b/ragl/textunit.py
@@ -27,16 +27,16 @@ class TextUnit:
 
 
     Attributes:
-        text_id:
-            Unique identifier.
         text:
             Text content.
-        distance:
-            Similarity distance.
-        chunk_position:
-            Position in parent text.
+        text_id:
+            Unique identifier.
         parent_id:
             ID of parent document.
+        chunk_position:
+            Position in parent text.
+        distance:
+            Similarity distance.
         source:
             Source of the text.
         confidence:
@@ -54,11 +54,11 @@ class TextUnit:
     """
 
     # pylint: disable=too-many-instance-attributes
-    text_id: str
     text: str
-    distance: float
-    chunk_position: int | None = None
+    text_id: str | None = None
     parent_id: str | None = None
+    chunk_position: int | None = None
+    distance: float = 1.0
     source: str | None = None
     confidence: float | str | None = None
     language: str | None = None
@@ -89,11 +89,11 @@ class TextUnit:
             # Clean up tags by removing quotes and brackets
             tags = [str(tag).strip("[]'\" ") for tag in tags]
         return cls(
-            text_id=data.get('text_id', ''),
             text=data.get('text', ''),
-            distance=data.get('distance', 0.0),
-            chunk_position=data.get('chunk_position'),
+            text_id=data.get('text_id'),
             parent_id=data.get('parent_id'),
+            chunk_position=data.get('chunk_position'),
+            distance=data.get('distance', 1.0),
             source=data.get('source'),
             confidence=data.get('confidence'),
             language=data.get('language'),
@@ -113,11 +113,11 @@ class TextUnit:
             A dict representation of the instance.
         """
         return {
-            'text_id':              self.text_id,
             'text':                 self.text,
-            'distance':             self.distance,
-            'chunk_position':       self.chunk_position,
+            'text_id':              self.text_id,
             'parent_id':            self.parent_id,
+            'chunk_position':       self.chunk_position,
+            'distance':             self.distance,
             'source':               self.source,
             'confidence':           self.confidence,
             'language':             self.language,
@@ -126,6 +126,44 @@ class TextUnit:
             'tags':                 self.tags,
             'timestamp':            self.timestamp,
         }
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Check equality with another object.
+
+        Compares text_id and text attributes for equality.
+
+        Args:
+            other:
+                Object to compare against.
+
+        Returns:
+            True if both objects are TextUnit instances with the
+            same values for key attributes, False otherwise.
+        """
+        if not isinstance(other, TextUnit):
+            return NotImplemented
+        return (self.text == other.text and
+                self.text_id == other.text_id and
+                self.parent_id == other.parent_id and
+                self.chunk_position == other.chunk_position and
+                self.distance == other.distance and
+                self.source == other.source and
+                self.confidence == other.confidence and
+                self.language == other.language and
+                self.section == other.section and
+                self.author == other.author and
+                self.tags == other.tags and
+                self.timestamp == other.timestamp)
+
+    def __len__(self) -> int:
+        """
+        Get the length of the text content.
+
+        Returns:
+            Length of the text string.
+        """
+        return len(self.text)
 
     def __str__(self) -> str:
         """

--- a/tests/functional/ragl/test_textunit.py
+++ b/tests/functional/ragl/test_textunit.py
@@ -97,9 +97,9 @@ class TestTextUnit(unittest.TestCase):
         with patch('time.time', return_value=2000000000):
             unit = TextUnit.from_dict({})
 
-        self.assertEqual(unit.text_id, '')
+        self.assertEqual(unit.text_id, None)
         self.assertEqual(unit.text, '')
-        self.assertEqual(unit.distance, 0.0)
+        self.assertEqual(unit.distance, 1.0)
         self.assertIsNone(unit.chunk_position)
         self.assertIsNone(unit.parent_id)
         self.assertIsNone(unit.source)
@@ -290,6 +290,91 @@ class TestTextUnit(unittest.TestCase):
         self.assertEqual(unit1.section, unit2.section)
         self.assertEqual(unit1.author, unit2.author)
         self.assertEqual(unit1.timestamp, unit2.timestamp)
+
+    def test_eq_identical_units(self):
+        """Test equality between identical TextUnits."""
+        unit1 = TextUnit(
+            text_id='test_id',
+            text='Sample text',
+            chunk_position=0,
+            parent_id='parent_1',
+            source='test_source',
+            timestamp=1234567890,
+            tags=['tag1', 'tag2'],
+            confidence=0.95,
+            language='en',
+            section='intro',
+            author='test_author',
+            distance=0.5
+        )
+
+        unit2 = TextUnit(
+            text_id='test_id',
+            text='Sample text',
+            chunk_position=0,
+            parent_id='parent_1',
+            source='test_source',
+            timestamp=1234567890,
+            tags=['tag1', 'tag2'],
+            confidence=0.95,
+            language='en',
+            section='intro',
+            author='test_author',
+            distance=0.5
+        )
+
+        self.assertEqual(unit1, unit2)
+
+    def test_eq_different_text_ids(self):
+        """Test inequality when text_ids differ."""
+        unit1 = TextUnit(text_id='id1', text='Same text')
+        unit2 = TextUnit(text_id='id2', text='Same text')
+
+        self.assertNotEqual(unit1, unit2)
+
+    def test_eq_different_text_content(self):
+        """Test inequality when text content differs."""
+        unit1 = TextUnit(text_id='same_id', text='Text one')
+        unit2 = TextUnit(text_id='same_id', text='Text two')
+
+        self.assertNotEqual(unit1, unit2)
+
+    def test_eq_different_metadata(self):
+        """Test inequality when metadata differs."""
+        unit1 = TextUnit(text_id='id', text='text', source='source1')
+        unit2 = TextUnit(text_id='id', text='text', source='source2')
+
+        self.assertNotEqual(unit1, unit2)
+
+    def test_eq_with_non_textunit(self):
+        """Test inequality when comparing with non-TextUnit object."""
+        unit = TextUnit(text_id='id', text='text')
+
+        self.assertNotEqual(unit, 'string')
+        self.assertNotEqual(unit, {'text_id': 'id', 'text': 'text'})
+        self.assertNotEqual(unit, None)
+
+    def test_len_returns_text_length(self):
+        """Test that len() returns the length of the text content."""
+        unit = TextUnit(text_id='id', text='Hello world')
+        self.assertEqual(len(unit), 11)
+
+    def test_len_empty_text(self):
+        """Test len() with empty text."""
+        unit = TextUnit(text_id='id', text='')
+        self.assertEqual(len(unit), 0)
+
+    def test_len_multiline_text(self):
+        """Test len() with multiline text."""
+        text = 'Line one\nLine two\nLine three'
+        unit = TextUnit(text_id='id', text=text)
+        self.assertEqual(len(unit), len(text))
+
+    def test_len_unicode_text(self):
+        """Test len() with unicode characters."""
+        text = 'Hello 世界 🌍'
+        unit = TextUnit(text_id='id', text=text)
+        self.assertEqual(len(unit), len(text))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added: TextUnit.__eq__ method
Added: TextUnit.__len__ method
Changed: TextUnit only required attribute is now TextUnit.text; defaults for text_id and distance
Changed: RedisVectoreStore.store_texts() to overwrite TextUnit.text_id when generating new text_id