### PR TITLE
RedisVectorStore Refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["tests", "work"]
 
 [project]
 name = "ragl"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
     "bleach",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["tests", "work"]
 
 [project]
 name = "ragl"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
     "bleach",
     "numpy",

--- a/ragl/protocols.py
+++ b/ragl/protocols.py
@@ -20,6 +20,7 @@ Classes:
 from typing import (
     Any,
     Protocol,
+    TypeAlias,
     runtime_checkable,
 )
 
@@ -31,8 +32,12 @@ __all__ = (
     'EmbedderProtocol',
     'RAGStoreProtocol',
     'TokenizerProtocol',
+    'TextEmbeddingPair',
     'VectorStoreProtocol',
 )
+
+
+TextEmbeddingPair: TypeAlias = tuple[TextUnit, np.ndarray]
 
 
 @runtime_checkable
@@ -98,7 +103,7 @@ class VectorStoreProtocol(Protocol):
 
     def store_texts(
             self,
-            texts_and_embeddings: list[tuple[TextUnit, np.ndarray]],
+            texts_and_embeddings: list[TextEmbeddingPair],
     ) -> list[str]:
         # pylint: disable=missing-function-docstring
         ...

--- a/ragl/schema.py
+++ b/ragl/schema.py
@@ -71,7 +71,9 @@ def sanitize_metadata(
             Raw metadata to sanitize (key-value Mapping).
         schema:
             Optional mapping of field names to type, default, and
-            conversion rules.
+            conversion rules. If not provided, a default schema is
+            used. If a field requires specific handling, the schema
+            should include a 'convert' callable to transform the value.
 
     Returns:
         Sanitized metadata as a dictionary.

--- a/ragl/store/redis.py
+++ b/ragl/store/redis.py
@@ -54,6 +54,7 @@ from ragl.exceptions import (
     StorageConnectionError,
     ValidationError,
 )
+from ragl.protocols import TextEmbeddingPair
 from ragl.schema import SchemaField, sanitize_metadata
 from ragl.textunit import TextUnit
 
@@ -439,7 +440,7 @@ class RedisVectorStore:
 
     def store_texts(
             self,
-            texts_and_embeddings: list[tuple[TextUnit, np.ndarray]],
+            texts_and_embeddings: list[TextEmbeddingPair],
     ) -> list[str]:
         """
         Store multiple texts and embeddings in batch.
@@ -968,60 +969,6 @@ class RedisVectorStore:
 
         return []
 
-    # def _parse_tags_from_retrieval( # todo
-    #         self,
-    #         tags: str | list[str] | None,
-    # ) -> list[str]:
-    #     # pylint: disable=too-many-branches
-    #     # pylint: disable=too-many-nested-blocks
-    #     """
-    #     Parse tags from Redis retrieval into a clean list.
-    #
-    #     Cleans and splits tags from Redis retrieval into a list of
-    #     tag strings. It handles both string and list formats, removing
-    #     unnecessary characters and whitespace. If tags are None,
-    #     it returns an empty list.
-    #
-    #     Args:
-    #         tags: Tags from Redis.
-    #
-    #     Returns:
-    #         List of tag strings.
-    #     """
-    #     _LOG.debug('Parsing tags from Redis retrieval')
-    #     if tags is None:
-    #         return []
-    #
-    #     clean_tags: list[str] = []
-    #     strip_chars = "[]'\" \t\n"
-    #
-    #     if isinstance(tags, str):
-    #         for tag in tags.split(self.TAG_SEPARATOR):
-    #             tag = tag.strip(strip_chars)
-    #             if tag:
-    #                 clean_tags.append(tag)
-    #
-    #     elif isinstance(tags, list):
-    #         for tag in tags:
-    #
-    #             if isinstance(tag, str):
-    #                 if self.TAG_SEPARATOR in tag:
-    #                     split_tags = tag.split(self.TAG_SEPARATOR)
-    #                     for t in split_tags:
-    #                         t = t.strip(strip_chars)
-    #                         if t:
-    #                             clean_tags.append(t)
-    #
-    #                 else:
-    #                     tag = tag.strip(strip_chars)
-    #                     if tag:
-    #                         clean_tags.append(tag)
-    #
-    #     else:
-    #         _LOG.warning('bad tags type: %s', type(tags))
-    #
-    #     return clean_tags
-
     def _prepare_single_text_entry(
             self,
             text_unit: TextUnit,
@@ -1223,7 +1170,7 @@ class RedisVectorStore:
 
     def _validate_and_prepare_batch_data(
             self,
-            texts_and_embeddings: list[tuple[TextUnit, np.ndarray]],
+            texts_and_embeddings: list[TextEmbeddingPair],
     ) -> dict[str, dict[str, Any]]:
         """
         Validate input structure and prepare batch data for storage.
@@ -1258,7 +1205,7 @@ class RedisVectorStore:
 
     @staticmethod
     def _validate_batch_input_structure(
-            texts_and_embeddings: list[tuple[TextUnit, np.ndarray]],
+            texts_and_embeddings: list[TextEmbeddingPair],
     ) -> None:
         """
         Validate the structure of the batch input.

--- a/ragl/store/redis.py
+++ b/ragl/store/redis.py
@@ -7,7 +7,7 @@ storage and retrieval of text embeddings with associated metadata. It
 leverages RedisVL (Redis Vector Library) for vector similarity search
 operations.
 
-Key Features:
+Features:
     - Vector similarity search using HNSW algorithm with cosine distance
     - Metadata storage and filtering (timestamps, tags, source info)
     - Schema validation and versioning
@@ -22,7 +22,8 @@ language, section, and author details. All metadata is sanitized
 according to a predefined schema before storage.
 
 Classes:
-    - RedisVectorStore: Main class for managing Redis vector storage.
+    RedisVectorStore:
+        Manage storage and retrieval of text embeddings in Redis.
 """
 
 import logging
@@ -683,56 +684,6 @@ class RedisVectorStore:
             },
         }
 
-    # @staticmethod  # todo
-    # def _create_validation_schema() -> dict[str, SchemaField]:
-    #     """
-    #     Create the validation schema for metadata fields.
-    #
-    #     Defines the expected types and default values for metadata
-    #     fields to ensure consistent sanitization before storage.
-    #
-    #     Returns:
-    #         Dictionary mapping field names to their schema definitions.
-    #     """
-    #     return {
-    #         'chunk_position': {
-    #             'type':    int,
-    #             'default': 0,
-    #         },
-    #         'timestamp':      {
-    #             'type':    int,
-    #             'default': 0,
-    #         },
-    #         'confidence':     {
-    #             'type':    float,
-    #             'default': 0.0,
-    #         },
-    #         'tags':           {
-    #             'type':    str,
-    #             'default': '',
-    #         },
-    #         'parent_id':      {
-    #             'type':    str,
-    #             'default': '',
-    #         },
-    #         'source':         {
-    #             'type':    str,
-    #             'default': '',
-    #         },
-    #         'language':       {
-    #             'type':    str,
-    #             'default': '',
-    #         },
-    #         'section':        {
-    #             'type':    str,
-    #             'default': '',
-    #         },
-    #         'author':         {
-    #             'type':    str,
-    #             'default': '',
-    #         },
-    #     }
-
     def _enforce_schema_version(self) -> None:
         """
         Check whether stored schema matches current version.
@@ -1130,11 +1081,6 @@ class RedisVectorStore:
             schema=self.validation_schema,
         )
 
-        # if 'tags' in sanitized:  # todo
-        #     sanitized['tags'] = self._prepare_tags_for_storage(
-        #         tags=sanitized['tags'],
-        #     )
-
         prepared_data = self._prepare_redis_payload(
             text=text,
             embedding=embedding,
@@ -1164,27 +1110,6 @@ class RedisVectorStore:
             sep = getattr(RedisVectorStore, 'TAG_SEPARATOR', ',')
             return sep.join(str(t).strip() for t in tags)
         return str(tags)
-
-    # def _prepare_tags_for_storage(self, tags: Any) -> str:  # todo
-    #     """
-    #     Convert tags to a string for Redis store.
-    #
-    #     Converts a list of tags or a single tag into a comma-separated
-    #     string for storage in Redis. It ensures that each tag is
-    #     stripped of whitespace and converted to a string. If tags
-    #     is not a list, it converts it to a string directly.
-    #
-    #     Args:
-    #         tags:
-    #             Tags to convert (list or other).
-    #
-    #     Returns:
-    #         Comma-separated string of tags.
-    #     """
-    #     _LOG.debug('Preparing tags for Redis storage')
-    #     if isinstance(tags, list):
-    #         return self.TAG_SEPARATOR.join(str(t).strip() for t in tags)
-    #     return str(tags)
 
     def _search_redis(self, vector_query: VectorQuery) -> Any:
         """

--- a/tests/functional/ragl/store/test_redis.py
+++ b/tests/functional/ragl/store/test_redis.py
@@ -2691,16 +2691,22 @@ class TestRedisVectorStore(unittest.TestCase):
                 index_name=self.index_name
             )
 
-        text_unit = TextUnit(text="Sample text",
-                             text_id=f'{TEXT_ID_PREFIX}123', distance=0.0)
+        # Create TextUnit with tags - this will go through the natural conversion flow
+        text_unit = TextUnit(
+            text="Sample text",
+            text_id=f'{TEXT_ID_PREFIX}123',
+            distance=0.0,
+            tags=['tag1', 'tag2']  # Set tags on the TextUnit
+        )
         embedding = np.random.rand(self.dimensions).astype(np.float32)
 
-        with patch('ragl.store.redis.sanitize_metadata',
-                   return_value={'tags': ['tag1', 'tag2']}):
-            text_id, prepared_data = store._prepare_single_text_entry(
-                text_unit, embedding)
+        # Let sanitize_metadata handle the conversion naturally
+        text_id, prepared_data = store._prepare_single_text_entry(
+            text_unit, embedding)
 
+        # Verify the tags were converted to comma-separated string
         self.assertEqual(prepared_data['tags'], 'tag1,tag2')
+        self.assertEqual(text_id, f'{TEXT_ID_PREFIX}123')
 
     @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
     def test_prepare_single_text_entry_invalid_dimensions(self,

--- a/tests/functional/ragl/store/test_redis.py
+++ b/tests/functional/ragl/store/test_redis.py
@@ -1139,7 +1139,7 @@ class TestRedisVectorStore(unittest.TestCase):
 
         with patch('ragl.store.redis.IndexSchema') as mock_schema_class:
             mock_schema_class.from_dict.return_value = self.mock_schema
-            result = store._create_redis_schema(self.index_name)
+            result = store._create_index_schema(self.index_name)
 
         self.assertEqual(result, self.mock_schema)
         mock_schema_class.from_dict.assert_called_once()
@@ -1296,7 +1296,7 @@ class TestRedisVectorStore(unittest.TestCase):
             )
 
         tags = ['tag1', 'tag2', 'tag3']
-        result = store._prepare_tags(tags)
+        result = store._prepare_tags_for_storage(tags)
         self.assertEqual(result, 'tag1,tag2,tag3')
 
     @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
@@ -1310,7 +1310,7 @@ class TestRedisVectorStore(unittest.TestCase):
             )
 
         tags = 'single_tag'
-        result = store._prepare_tags(tags)
+        result = store._prepare_tags_for_storage(tags)
         self.assertEqual(result, 'single_tag')
 
     @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')

--- a/tests/functional/ragl/store/test_redis.py
+++ b/tests/functional/ragl/store/test_redis.py
@@ -3021,6 +3021,256 @@ class TestRedisVectorStore(unittest.TestCase):
         result = store._parse_list_tags(["tag1,", ",tag2", "tag3"])
         self.assertEqual(result, ["tag1", "tag2", "tag3"])
 
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_none(self, mock_validate_sync):
+        """Test preparing None tags returns empty list."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        result = store._prepare_tags_for_storage(None)
+        self.assertEqual(result, '')
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_empty_string(self, mock_validate_sync):
+        """Test preparing empty string tags raises ValidationError."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        with self.assertRaises(ValidationError) as cm:
+            store._prepare_tags_for_storage('')
+        self.assertIn('Tag cannot be empty or whitespace-only',
+                      str(cm.exception))
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_whitespace_string(self,
+                                                        mock_validate_sync):
+        """Test preparing whitespace-only string tags raises ValidationError."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        with self.assertRaises(ValidationError) as cm:
+            store._prepare_tags_for_storage('   \n\t   ')
+        self.assertIn('Tag cannot be empty or whitespace-only',
+                      str(cm.exception))
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_single_string(self, mock_validate_sync):
+        """Test preparing single string tag."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        result = store._prepare_tags_for_storage('single_tag')
+        self.assertEqual(result, 'single_tag')
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_string_with_whitespace(self,
+                                                             mock_validate_sync):
+        """Test preparing string tag with surrounding whitespace."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        result = store._prepare_tags_for_storage('  tag_with_spaces  ')
+        self.assertEqual(result, 'tag_with_spaces')
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_empty_list(self, mock_validate_sync):
+        """Test preparing empty list tags."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        result = store._prepare_tags_for_storage([])
+        self.assertEqual(result, '')
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_single_item_list(self,
+                                                       mock_validate_sync):
+        """Test preparing list with single tag."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        result = store._prepare_tags_for_storage(['single_tag'])
+        self.assertEqual(result, 'single_tag')
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_multiple_item_list(self,
+                                                         mock_validate_sync):
+        """Test preparing list with multiple tags."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        result = store._prepare_tags_for_storage(['tag1', 'tag2', 'tag3'])
+        self.assertEqual(result, 'tag1,tag2,tag3')
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_list_with_empty_strings(self,
+                                                              mock_validate_sync):
+        """Test preparing list with empty strings raises ValidationError."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        with self.assertRaises(ValidationError) as cm:
+            store._prepare_tags_for_storage(['tag1', '', 'tag2'])
+        self.assertIn('Tag cannot be empty or whitespace-only',
+                      str(cm.exception))
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_list_with_whitespace(self,
+                                                           mock_validate_sync):
+        """Test preparing list with tags containing whitespace."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        result = store._prepare_tags_for_storage(
+            ['  tag1  ', '  tag2  ', '  tag3  '])
+        self.assertEqual(result, 'tag1,tag2,tag3')
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_list_all_empty(self, mock_validate_sync):
+        """Test preparing list with all empty/whitespace tags raises ValidationError."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        with self.assertRaises(ValidationError) as cm:
+            store._prepare_tags_for_storage(['', '   ', '\n\t'])
+        self.assertIn('Tag cannot be empty or whitespace-only',
+                      str(cm.exception))
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_list_with_non_strings(self,
+                                                            mock_validate_sync):
+        """Test preparing list with non-string elements raises ValidationError."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        with self.assertRaises(ValidationError) as cm:
+            store._prepare_tags_for_storage(['tag1', 123, 'tag2'])
+        self.assertIn('All tags must be strings', str(cm.exception))
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_unsupported_type(self,
+                                                       mock_validate_sync):
+        """Test preparing tags with unsupported type raises ValidationError."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        # Test with dict
+        with self.assertRaises(ValidationError) as cm:
+            store._prepare_tags_for_storage({'key': 'value'})
+        self.assertIn('Invalid tags type', str(cm.exception))
+
+        # Test with int
+        with self.assertRaises(ValidationError) as cm:
+            store._prepare_tags_for_storage(123)
+        self.assertIn('Invalid tags type', str(cm.exception))
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_tags_with_separator(self,
+                                                          mock_validate_sync):
+        """Test that tags containing TAG_SEPARATOR raise ValidationError."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        with self.assertRaises(ValidationError) as cm:
+            store._prepare_tags_for_storage(['tag1,tag2'])
+        self.assertIn('Tag cannot contain delimiter', str(cm.exception))
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_tags_with_newlines(self,
+                                                         mock_validate_sync):
+        """Test that tags containing newlines raise ValidationError."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        with self.assertRaises(ValidationError) as cm:
+            store._prepare_tags_for_storage(['tag1\ntag2'])
+        self.assertIn('Tag cannot contain newline', str(cm.exception))
+
+    @patch('redisvl.redis.connection.RedisConnectionFactory.validate_sync_redis')
+    def test_prepare_tags_for_storage_valid_complex_tags(self,
+                                                         mock_validate_sync):
+        """Test preparing valid complex tags."""
+        with patch.object(RedisVectorStore, '_enforce_schema_version'):
+            store = RedisVectorStore(
+                redis_client=self.mock_redis_client,
+                dimensions=self.dimensions,
+                index_name=self.index_name
+            )
+
+        # Test valid special characters
+        result = store._prepare_tags_for_storage(
+            ['category:ai', 'type:text', 'version:1.0'])
+        self.assertEqual(result, 'category:ai,type:text,version:1.0')
+
+        # Test valid punctuation
+        result = store._prepare_tags_for_storage(
+            ['tag-with-dash', 'tag_with_underscore', 'tag.with.dots'])
+        self.assertEqual(result,
+                         'tag-with-dash,tag_with_underscore,tag.with.dots')
+
+        # Test unicode characters
+        result = store._prepare_tags_for_storage(['тег', 'étiquette', '标签'])
+        self.assertEqual(result, 'тег,étiquette,标签')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/sentencetransformer_redis.py
+++ b/tests/integration/sentencetransformer_redis.py
@@ -1715,6 +1715,63 @@ class TestRaglIntegration:
         assert time_sort_duration < 5.0, "Time sorting too slow"
         assert distance_sort_duration < 5.0, "Distance sorting too slow"
 
+    def test_tag_storage_and_retrieval(self):
+        """Test that tags are properly stored and retrieved with correct format conversion."""
+
+        # Test with list of tags
+        text_unit_with_tags = TextUnit(
+            text="Document about machine learning algorithms",
+            tags=['ml', 'algorithms', 'data-science', 'python'],
+            source='test_docs',
+            author='test_author'
+        )
+
+        # Store the document
+        stored_ids = self.manager.add_texts([text_unit_with_tags])
+        assert len(stored_ids) == 1
+
+        # Retrieve and verify tags are returned as list
+        contexts = self.manager.get_context(
+            query="machine learning",
+            top_k=1
+        )
+
+        assert len(contexts) >= 1
+        retrieved_context = contexts[0]
+
+        # Verify tags are returned as list with correct values
+        assert isinstance(retrieved_context.tags, list)
+        assert set(retrieved_context.tags) == {'ml', 'algorithms',
+                                               'data-science', 'python'}
+
+        # Test with single tag (string)
+        text_unit_single_tag = TextUnit(
+            text="Document about databases",
+            tags=['database'],  # Still provide as list for consistency
+            source='test_docs'
+        )
+
+        stored_ids = self.manager.add_texts([text_unit_single_tag])
+        assert len(stored_ids) == 1
+
+        contexts = self.manager.get_context(query="database", top_k=1)
+        assert len(contexts) >= 1
+        assert isinstance(contexts[0].tags, list)
+        assert contexts[0].tags == ['database']
+
+        # Test with empty tags
+        text_unit_no_tags = TextUnit(
+            text="Document without tags",
+            source='test_docs'
+        )
+
+        stored_ids = self.manager.add_texts([text_unit_no_tags])
+        contexts = self.manager.get_context(query="without", top_k=1)
+        assert len(contexts) >= 1
+        # Should return empty list for tags, not None or empty string
+        assert isinstance(contexts[0].tags, list)
+        assert contexts[0].tags == []
+
 
 if __name__ == "__main__":
     import sys

--- a/tests/integration/sentencetransformer_redis.py
+++ b/tests/integration/sentencetransformer_redis.py
@@ -1310,6 +1310,411 @@ class TestRaglIntegration:
                 assert len(
                     shared_words) > 0, "No word overlap between consecutive chunks"
 
+    def test_sort_by_time_functionality(self):
+        """Test that sort_by_time parameter correctly orders results by timestamp."""
+
+        # Create TextUnits with different timestamps
+        base_time = int(time.time())
+        text_units = [
+            TextUnit(
+                text="First document about machine learning fundamentals",
+                source="doc1.pdf",
+                timestamp=base_time - 3600,  # 1 hour ago
+                parent_id="doc:time_test_1"
+            ),
+            TextUnit(
+                text="Second document about machine learning algorithms",
+                source="doc2.pdf",
+                timestamp=base_time - 1800,  # 30 minutes ago
+                parent_id="doc:time_test_2"
+            ),
+            TextUnit(
+                text="Third document about machine learning applications",
+                source="doc3.pdf",
+                timestamp=base_time - 900,  # 15 minutes ago
+                parent_id="doc:time_test_3"
+            )
+        ]
+
+        # Add documents
+        self.manager.add_texts(texts_or_units=text_units)
+
+        # Test sort by time (chronological order)
+        contexts_by_time = self.manager.get_context(
+            query="machine learning",
+            top_k=3,
+            sort_by_time=True
+        )
+
+        assert len(contexts_by_time) >= 3
+
+        # Verify chronological ordering (oldest first)
+        timestamps = [ctx.timestamp for ctx in contexts_by_time]
+        assert timestamps == sorted(
+            timestamps), "Results not sorted chronologically"
+
+        # Test sort by distance (default behavior)
+        contexts_by_distance = self.manager.get_context(
+            query="machine learning",
+            top_k=3,
+            sort_by_time=False
+        )
+
+        assert len(contexts_by_distance) >= 3
+
+        # Verify distance ordering (most relevant first)
+        distances = [ctx.distance for ctx in contexts_by_distance]
+        assert distances == sorted(
+            distances), "Results not sorted by relevance"
+
+        # The two orderings should potentially be different
+        time_order_ids = [ctx.text_id for ctx in contexts_by_time]
+        distance_order_ids = [ctx.text_id for ctx in contexts_by_distance]
+
+        logging.info(f"Time order: {time_order_ids}")
+        logging.info(f"Distance order: {distance_order_ids}")
+
+    def test_time_range_filtering_with_sorting(self):
+        """Test time range filtering combined with different sorting options."""
+
+        base_time = int(time.time())
+
+        # Create documents spanning different time periods
+        text_units = [
+            TextUnit(
+                text="Ancient document about programming concepts",
+                timestamp=base_time - 7200,  # 2 hours ago
+                parent_id="doc:ancient"
+            ),
+            TextUnit(
+                text="Recent document about programming languages",
+                timestamp=base_time - 1800,  # 30 minutes ago
+                parent_id="doc:recent"
+            ),
+            TextUnit(
+                text="Very recent document about programming frameworks",
+                timestamp=base_time - 600,  # 10 minutes ago
+                parent_id="doc:very_recent"
+            ),
+            TextUnit(
+                text="Brand new document about programming best practices",
+                timestamp=base_time - 60,  # 1 minute ago
+                parent_id="doc:brand_new"
+            )
+        ]
+
+        self.manager.add_texts(texts_or_units=text_units)
+
+        # Filter to last hour and sort by time
+        hour_ago = base_time - 3600
+        contexts_filtered_by_time = self.manager.get_context(
+            query="programming",
+            top_k=5,
+            min_time=hour_ago,
+            sort_by_time=True
+        )
+
+        # Should exclude the 2-hour-old document
+        assert len(contexts_filtered_by_time) == 3
+
+        # Verify all results are within time range
+        for ctx in contexts_filtered_by_time:
+            assert ctx.timestamp >= hour_ago
+
+        # Verify chronological ordering
+        timestamps = [ctx.timestamp for ctx in contexts_filtered_by_time]
+        assert timestamps == sorted(timestamps)
+
+        # Same filter but sort by distance
+        contexts_filtered_by_distance = self.manager.get_context(
+            query="programming",
+            top_k=5,
+            min_time=hour_ago,
+            sort_by_time=False
+        )
+
+        assert len(contexts_filtered_by_distance) == 3
+
+        # Verify distance ordering
+        distances = [ctx.distance for ctx in contexts_filtered_by_distance]
+        assert distances == sorted(distances)
+
+    def test_time_window_filtering(self):
+        """Test filtering with both min_time and max_time parameters."""
+
+        base_time = int(time.time())
+
+        # Create documents at specific time intervals
+        documents_with_times = [
+            ("Document from 3 hours ago about data science",
+             base_time - 10800),
+            ("Document from 2 hours ago about data analysis",
+             base_time - 7200),
+            ("Document from 1 hour ago about data mining", base_time - 3600),
+            ("Document from 30 minutes ago about data visualization",
+             base_time - 1800),
+            ("Very recent document about data engineering", base_time - 300)
+        ]
+
+        text_units = [
+            TextUnit(text=text, timestamp=timestamp,
+                     parent_id=f"doc:window_{i}")
+            for i, (text, timestamp) in enumerate(documents_with_times)
+        ]
+
+        self.manager.add_texts(texts_or_units=text_units)
+
+        # Filter to 2-hour window (between 3 hours ago and just before 1 hour ago)
+        min_time = base_time - 10800  # 3 hours ago
+        max_time = base_time - 3601  # Just before 1 hour ago (exclusive of 1-hour doc)
+
+        windowed_contexts = self.manager.get_context(
+            query="data",
+            top_k=5,
+            min_time=min_time,
+            max_time=max_time,
+            sort_by_time=True
+        )
+
+        # Should only get the 3-hour and 2-hour old documents
+        assert len(windowed_contexts) == 2
+
+        # Verify all results are within time window
+        for ctx in windowed_contexts:
+            assert min_time <= ctx.timestamp <= max_time
+
+        # Verify chronological ordering
+        timestamps = [ctx.timestamp for ctx in windowed_contexts]
+        assert timestamps == sorted(timestamps)
+
+        # Test narrow window (last 45 minutes)
+        narrow_min = base_time - 2700  # 45 minutes ago
+        narrow_contexts = self.manager.get_context(
+            query="data",
+            top_k=5,
+            min_time=narrow_min,
+            sort_by_time=True
+        )
+
+        # Should only get the 30-minute and 5-minute old documents
+        assert len(narrow_contexts) == 2
+        for ctx in narrow_contexts:
+            assert ctx.timestamp >= narrow_min
+
+    def test_distance_precision_and_sorting(self):
+        """Test that distance values are precise and sorting works correctly."""
+        # Add documents with varying relevance to query
+        documents = [
+            "Machine learning algorithms analyze data patterns effectively",
+            "Algorithms can be used for machine data analysis in learning systems",
+            "Data analysis involves statistical methods and machine tools",
+            "Cooking recipes require precise timing and temperature control"
+        ]
+
+        self.manager.add_texts(texts_or_units=documents)
+
+        contexts = self.manager.get_context(
+            query="machine learning algorithms",
+            top_k=4,
+            sort_by_time=False  # Sort by distance (default)
+        )
+
+        assert len(contexts) >= 4
+
+        # Verify distance values are numeric and in valid range
+        for ctx in contexts:
+            assert isinstance(ctx.distance, (int, float))
+            assert 0.0 <= ctx.distance <= 1.0
+
+        # Verify strict ordering by distance (most relevant first)
+        distances = [ctx.distance for ctx in contexts]
+        assert distances == sorted(
+            distances), "Results not properly sorted by distance"
+
+        # Most relevant documents should be ML-related (not cooking)
+        most_relevant = contexts[0]
+        ml_related_terms = ["machine", "learning", "algorithms", "data",
+                            "analysis"]
+        assert any(
+            term in most_relevant.text.lower() for term in ml_related_terms)
+
+        # Least relevant should be the cooking document
+        least_relevant = contexts[-1]
+        assert "cooking" in least_relevant.text.lower()
+
+        # Verify ML documents have lower distances than cooking document
+        ml_contexts = [ctx for ctx in contexts if any(
+            term in ctx.text.lower()
+            for term in
+            ["machine", "learning", "algorithms", "data", "analysis"]
+        )]
+        cooking_contexts = [ctx for ctx in contexts if
+                            "cooking" in ctx.text.lower()]
+
+        if ml_contexts and cooking_contexts:
+            max_ml_distance = max(ctx.distance for ctx in ml_contexts)
+            min_cooking_distance = min(
+                ctx.distance for ctx in cooking_contexts)
+            assert max_ml_distance < min_cooking_distance, "ML documents should be more relevant than cooking"
+
+        logging.info(
+            f"Distance ordering: {[(ctx.text[:50], ctx.distance) for ctx in contexts]}")
+
+    def test_empty_results_sorting_behavior(self):
+        """Test sorting behavior when no results match the query or time filters."""
+        # Add some documents with known timestamp
+        current_time = int(time.time())
+
+        # Add document with current timestamp
+        text_unit = TextUnit(
+            text="Document about completely different topic like gardening",
+            timestamp=current_time
+        )
+        self.manager.add_texts([text_unit])
+
+        # Query for unrelated content
+        contexts = self.manager.get_context(
+            query="quantum physics nuclear science",
+            top_k=5,
+            sort_by_time=True
+        )
+
+        # Should return empty list or very low relevance results
+        if len(contexts) > 0:
+            # If any results returned, verify they're properly sorted
+            timestamps = [ctx.timestamp for ctx in contexts]
+            assert timestamps == sorted(timestamps)
+
+        # Test with time filter that excludes everything
+        # Use a future time that's definitely after the document timestamp
+        future_time = current_time + 7200  # 2 hours in future
+
+        future_contexts = self.manager.get_context(
+            query="gardening",
+            top_k=5,
+            min_time=future_time,
+            sort_by_time=True
+        )
+
+        # Should return empty results
+        assert len(future_contexts) == 0, (f"Expected no results with "
+                                           f"future min_time, got {len(future_contexts)}")
+
+        # Test with max_time filter that excludes everything
+        past_time = current_time - 7200  # 2 hours in past
+
+        past_contexts = self.manager.get_context(
+            query="gardening",
+            top_k=5,
+            max_time=past_time,
+            sort_by_time=True
+        )
+
+        # Should return empty results since document is newer than max_time
+        assert len(past_contexts) == 0, (f"Expected no results with past "
+                                         f"max_time, got {len(past_contexts)}")
+
+        logging.info("Empty results sorting behavior verified")
+
+    def test_sort_stability_with_identical_values(self):
+        """Test sorting stability when documents have identical timestamps or distances."""
+
+        # Create documents with identical timestamps
+        same_timestamp = int(time.time()) - 1800  # 30 minutes ago
+        identical_time_units = [
+            TextUnit(
+                text=f"Document {i} about identical timestamp testing",
+                timestamp=same_timestamp,
+                parent_id=f"doc:identical_{i}"
+            )
+            for i in range(3)
+        ]
+
+        self.manager.add_texts(texts_or_units=identical_time_units)
+
+        # Test sort by time with identical timestamps
+        contexts_by_time = self.manager.get_context(
+            query="identical timestamp",
+            top_k=3,
+            sort_by_time=True
+        )
+
+        assert len(contexts_by_time) >= 3
+
+        # All should have same timestamp
+        timestamps = [ctx.timestamp for ctx in contexts_by_time]
+        assert all(ts == same_timestamp for ts in timestamps)
+
+        # Test sort by distance - should have very similar distances for similar content
+        contexts_by_distance = self.manager.get_context(
+            query="identical timestamp testing",
+            top_k=3,
+            sort_by_time=False
+        )
+
+        assert len(contexts_by_distance) >= 3
+
+        # Distances should be very similar for nearly identical content
+        distances = [ctx.distance for ctx in contexts_by_distance]
+        distance_range = max(distances) - min(distances)
+        assert distance_range < 0.1, "Distances for similar content should be close"
+
+    def test_large_result_set_sorting_performance(self):
+        """Test sorting performance with larger result sets."""
+        import time
+
+        # Add many documents with varying timestamps
+        base_time = int(time.time())
+        large_batch = []
+
+        for i in range(50):
+            text_unit = TextUnit(
+                text=f"Performance test document {i} about data processing topic {i % 5}",
+                timestamp=base_time - (i * 60),
+                # Each doc 1 minute older than previous
+                parent_id=f"doc:perf_{i}"
+            )
+            large_batch.append(text_unit)
+
+        self.manager.add_texts(texts_or_units=large_batch)
+
+        # Test time-based sorting performance
+        start_time = time.time()
+        contexts_by_time = self.manager.get_context(
+            query="data processing",
+            top_k=20,
+            sort_by_time=True
+        )
+        time_sort_duration = time.time() - start_time
+
+        assert len(contexts_by_time) >= 20
+
+        # Verify proper time ordering
+        timestamps = [ctx.timestamp for ctx in contexts_by_time]
+        assert timestamps == sorted(timestamps)
+
+        # Test distance-based sorting performance
+        start_time = time.time()
+        contexts_by_distance = self.manager.get_context(
+            query="data processing",
+            top_k=20,
+            sort_by_time=False
+        )
+        distance_sort_duration = time.time() - start_time
+
+        assert len(contexts_by_distance) >= 20
+
+        # Verify proper distance ordering
+        distances = [ctx.distance for ctx in contexts_by_distance]
+        assert distances == sorted(distances)
+
+        logging.info(f"Time sort took {time_sort_duration:.3f}s, "
+                     f"distance sort took {distance_sort_duration:.3f}s")
+
+        # Both should complete reasonably quickly
+        assert time_sort_duration < 5.0, "Time sorting too slow"
+        assert distance_sort_duration < 5.0, "Distance sorting too slow"
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
Changed: RedisVectorStore.__init__() logic broken into submethods
Changed: RedisVectorStore.store_text() logic broken into submethods
Renamed: RedisVectorStore.metadata_schema -> RedisVectorStore.validation_schema
Renamed: RedisVectorStore._prepare_tags_for_storage() -> RedisVectorStore.prepare_tags_for_storage()
Changed: RedisVectorStore.prepare_tags_for_storage() now silently skips empty/whitespace-only tags
Changed: RedisVectorStore.prepare_tags_for_storage() now raises ValidationError on bad / dangerous tag values
Changed: RedisVectorStore.prepare_tags_for_storage() is now presented as the 'convert' callable for the 'tags' within RedisVectorStore.validation_schema -- this schema is injected into ragl.schema.sanitize_metadata when preparing data for storage. Previously, this feature was unused and tag cleanup logic was being called against the metadata directly, after the call to sanitize_metadata.
Added: Several new integration tests, covering additional edge cases and specific data / metadata scenarios

